### PR TITLE
Use latest spring-boot release and maven plugin defined by that version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.2.1.RELEASE</version>
+    <version>1.3.1.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -47,16 +47,6 @@
       <url>http://dist.gemstone.com/maven/release</url>
     </repository>
   </repositories>
-  <!--
-    Needed for spring-boot-maven-plugin:1.3.0.M4 referenced in worblehat-web/pom.xml
-    can be removed once spring-boot 1.3.0 has been released.
-  -->
-  <pluginRepositories>
-    <pluginRepository>
-      <id>spring-libs-milestones</id>
-      <url>http://repo.spring.io/libs-milestone</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencyManagement>
     <dependencies>

--- a/worblehat-web/pom.xml
+++ b/worblehat-web/pom.xml
@@ -85,7 +85,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>1.3.0.M4</version>
 				<configuration>
 					<executable>true</executable>
 				</configuration>


### PR DESCRIPTION
We had to use version 1.3.0.M4 of spring-boot-maven-plugin to create the executable jar. Since 1.3.1.RELEASE is now available we can drop the special configuration that pulls in the 1.3.0.M4 release of spring-boot-maven-plugin.