### PR TITLE
fix maven surefire plugin config for worblehat-domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
                     <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
"mvn clean install" did not succeed (FAILURE on worblehat-domain). The surefire plugin needed some configuration to make the project build.
