### PR TITLE
Migrate test assertions from Hamcrest to AssertJ

### DIFF
--- a/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/business/Library.java
+++ b/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/business/Library.java
@@ -1,10 +1,7 @@
 package de.codecentric.psd.worblehat.acceptancetests.step.business;
 
 import static de.codecentric.psd.worblehat.acceptancetests.step.StepUtilities.doWithEach;
-import static org.hamcrest.CoreMatchers.everyItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasProperty;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import de.codecentric.psd.worblehat.domain.Book;
 import de.codecentric.psd.worblehat.domain.BookService;
@@ -80,11 +77,11 @@ public class Library {
   // *****************
 
   @Then("the library contains {int} copies of the book with {string}")
-  public void shouldContainCopiesOfBook(Integer nrOfCopies, String isbn) {
+  public void shouldContainCopiesOfBook(int nrOfCopies, String isbn) {
     waitForServerResponse();
     Set<Book> books = bookService.findBooksByIsbn(isbn);
-    assertThat(books.size(), is(nrOfCopies));
-    assertThat(books, everyItem(hasProperty("isbn", is(isbn))));
+    assertThat(books).hasSize(nrOfCopies);
+    assertThat(books).extracting(Book::getIsbn).containsOnly(isbn);
   }
 
   private void waitForServerResponse() {

--- a/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/page/BookList.java
+++ b/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/page/BookList.java
@@ -1,8 +1,7 @@
 package de.codecentric.psd.worblehat.acceptancetests.step.page;
 
 import static de.codecentric.psd.worblehat.acceptancetests.step.StepUtilities.doWithEach;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import de.codecentric.psd.worblehat.acceptancetests.adapter.SeleniumAdapter;
 import de.codecentric.psd.worblehat.acceptancetests.adapter.wrapper.HtmlBook;
@@ -35,11 +34,11 @@ public class BookList {
     seleniumAdapter.gotoPage(Page.BOOKLIST);
     HtmlBookList htmlBookList = seleniumAdapter.getTableContent(PageElement.BOOKLIST);
     HtmlBook htmlBook = htmlBookList.getBookByIsbn(isbn);
-    assertThat(title, is(htmlBook.getTitle()));
-    assertThat(author, is(htmlBook.getAuthor()));
-    assertThat(year, is(htmlBook.getYearOfPublication()));
-    assertThat(edition, is(htmlBook.getEdition()));
-    assertThat(isbn, is(htmlBook.getIsbn()));
+    assertThat(title).isEqualTo(htmlBook.getTitle());
+    assertThat(author).isEqualTo(htmlBook.getAuthor());
+    assertThat(year).isEqualTo(htmlBook.getYearOfPublication());
+    assertThat(edition).isEqualTo(htmlBook.getEdition());
+    assertThat(isbn).isEqualTo(htmlBook.getIsbn());
   }
 
   @Then("the booklist shows that book with {string} as {string}")
@@ -50,16 +49,16 @@ public class BookList {
     HtmlBook htmlBook = htmlBookList.getBookByIsbn(isbn);
     switch (property) {
       case "title":
-        assertThat(htmlBook.getTitle(), is(value));
+        assertThat(htmlBook.getTitle()).isEqualTo(value);
         break;
       case "author":
-        assertThat(htmlBook.getAuthor(), is(value));
+        assertThat(htmlBook.getAuthor()).isEqualTo(value);
         break;
       case "year":
-        assertThat(htmlBook.getYearOfPublication(), is(value));
+        assertThat(htmlBook.getYearOfPublication()).isEqualTo(value);
         break;
       case "isbn":
-        assertThat(htmlBook.getIsbn(), is(value));
+        assertThat(htmlBook.getIsbn()).isEqualTo(value);
         break;
     }
   }
@@ -68,7 +67,7 @@ public class BookList {
   public void libraryIsEmpty() {
     seleniumAdapter.gotoPage(Page.BOOKLIST);
     HtmlBookList htmlBookList = seleniumAdapter.getTableContent(PageElement.BOOKLIST);
-    assertThat(htmlBookList.size(), is(0));
+    assertThat(htmlBookList.size()).isEqualTo(0);
   }
 
   @Then("the booklist lists {string} as borrower only for the book(s) with isbn(s) {string}")
@@ -79,7 +78,7 @@ public class BookList {
         isbns,
         (isbn) -> {
           HtmlBook htmlBook = htmlBookList.getBookByIsbn(isbn);
-          assertThat(htmlBook.getBorrower(), is(borrower));
+          assertThat(htmlBook.getBorrower()).isEqualTo(borrower);
         });
   }
 
@@ -89,8 +88,7 @@ public class BookList {
     HtmlBookList htmlBookList = seleniumAdapter.getTableContent(PageElement.BOOKLIST);
     doWithEach(
         isbns,
-        (isbn) ->
-            assertThat(htmlBookList.getBookByIsbn(isbn).getBorrower(), is(isEmptyOrNullString())));
+        (isbn) -> assertThat(htmlBookList.getBookByIsbn(isbn).getBorrower()).isNullOrEmpty());
   }
 
   @Then("books {string} are still borrowed by borrower {string}")
@@ -98,6 +96,7 @@ public class BookList {
     seleniumAdapter.gotoPage(Page.BOOKLIST);
     HtmlBookList htmlBookList = seleniumAdapter.getTableContent(PageElement.BOOKLIST);
     doWithEach(
-        isbns, (isbn) -> assertThat(htmlBookList.getBookByIsbn(isbn).getBorrower(), is(borrower2)));
+        isbns,
+        (isbn) -> assertThat(htmlBookList.getBookByIsbn(isbn).getBorrower()).isEqualTo(borrower2));
   }
 }

--- a/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/page/BorrowBook.java
+++ b/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/page/BorrowBook.java
@@ -1,8 +1,7 @@
 package de.codecentric.psd.worblehat.acceptancetests.step.page;
 
 import static de.codecentric.psd.worblehat.acceptancetests.step.StepUtilities.doWithEach;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import de.codecentric.psd.worblehat.acceptancetests.adapter.SeleniumAdapter;
 import de.codecentric.psd.worblehat.acceptancetests.adapter.wrapper.Page;
@@ -56,7 +55,7 @@ public class BorrowBook {
           seleniumAdapter.typeIntoField("isbn", isbn);
           seleniumAdapter.clickOnPageElement(PageElement.BORROWBOOKBUTTON);
           String errorMessage = seleniumAdapter.getTextFromElement(PageElement.ISBN_ERROR);
-          assertThat(errorMessage, is(message));
+          assertThat(errorMessage).isEqualTo(message);
         });
   }
 }

--- a/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/page/InsertBook.java
+++ b/worblehat-acceptancetests/src/test/java/de/codecentric/psd/worblehat/acceptancetests/step/page/InsertBook.java
@@ -1,7 +1,6 @@
 package de.codecentric.psd.worblehat.acceptancetests.step.page;
 
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import de.codecentric.psd.worblehat.acceptancetests.adapter.SeleniumAdapter;
 import de.codecentric.psd.worblehat.acceptancetests.adapter.wrapper.Page;
@@ -71,7 +70,7 @@ public class InsertBook {
   @Then("the page contains error message for field {string}")
   public void pageContainsErrorMessage(String field) {
     String errorMessage = seleniumAdapter.getTextFromElement(PageElement.errorFor(field));
-    assertThat(errorMessage, notNullValue());
+    assertThat(errorMessage).isNotNull();
   }
   // *****************
   // *** U T I L *****

--- a/worblehat-domain/pom.xml
+++ b/worblehat-domain/pom.xml
@@ -26,12 +26,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.npathai</groupId>
-            <artifactId>hamcrest-optional</artifactId>
-            <version>2.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
@@ -50,9 +44,9 @@
             <version>32.0.0-jre</version>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-test</artifactId>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/StandardBookService.java
+++ b/worblehat-domain/src/main/java/de/codecentric/psd/worblehat/domain/StandardBookService.java
@@ -15,7 +15,7 @@ public class StandardBookService implements BookService {
 
   @Autowired
   public StandardBookService(
-    BorrowingRepository borrowingRepository, BookRepository bookRepository) {
+      BorrowingRepository borrowingRepository, BookRepository bookRepository) {
     this.borrowingRepository = borrowingRepository;
     this.bookRepository = bookRepository;
   }
@@ -27,7 +27,7 @@ public class StandardBookService implements BookService {
   @Override
   public void returnAllBooksByBorrower(String borrowerEmailAddress) {
     List<Borrowing> borrowingsByUser =
-      borrowingRepository.findBorrowingsByBorrower(borrowerEmailAddress);
+        borrowingRepository.findBorrowingsByBorrower(borrowerEmailAddress);
     for (Borrowing borrowing : borrowingsByUser) {
       borrowingRepository.delete(borrowing);
     }
@@ -38,14 +38,14 @@ public class StandardBookService implements BookService {
     Set<Book> books = bookRepository.findByIsbn(isbn);
 
     Optional<Book> unborrowedBook =
-      books.stream().filter(book -> book.getBorrowing() == null).findFirst();
+        books.stream().filter(book -> book.getBorrowing() == null).findFirst();
 
     return unborrowedBook.map(
-      book -> {
-        book.borrowNowByBorrower(borrower);
-        borrowingRepository.save(book.getBorrowing());
-        return book.getBorrowing();
-      });
+        book -> {
+          book.borrowNowByBorrower(borrower);
+          borrowingRepository.save(book.getBorrowing());
+          return book.getBorrowing();
+        });
   }
 
   @Override
@@ -60,11 +60,11 @@ public class StandardBookService implements BookService {
 
   @Override
   public Optional<Book> createBook(
-    @Nonnull String title,
-    @Nonnull String author,
-    @Nonnull String edition,
-    @Nonnull String isbn,
-    int yearOfPublication) {
+      @Nonnull String title,
+      @Nonnull String author,
+      @Nonnull String edition,
+      @Nonnull String isbn,
+      int yearOfPublication) {
     Book book = new Book(title, author, edition, isbn, yearOfPublication);
 
     Optional<Book> bookFromRepo = bookRepository.findTopByIsbn(isbn);

--- a/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/BookTest.java
+++ b/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/BookTest.java
@@ -1,8 +1,6 @@
 package de.codecentric.psd.worblehat.domain;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +24,7 @@ class BookTest {
             BOOK.getIsbn(),
             BOOK.getYearOfPublication());
     anotherCopy.setAuthor("Bene");
-    assertThat(BOOK.isSameCopy(anotherCopy), is(false));
+    assertThat(BOOK.isSameCopy(anotherCopy)).isFalse();
   }
 
   @Test
@@ -39,7 +37,7 @@ class BookTest {
             BOOK.getIsbn(),
             BOOK.getYearOfPublication());
     anotherCopy.setTitle("Lord of the Rings");
-    assertThat(BOOK.isSameCopy(anotherCopy), is(false));
+    assertThat(BOOK.isSameCopy(anotherCopy)).isFalse();
   }
 
   @Test
@@ -54,29 +52,30 @@ class BookTest {
     anotherCopy.setEdition("2000");
     anotherCopy.setIsbn("123456789X");
     anotherCopy.setYearOfPublication(2010);
-    assertThat(BOOK.isSameCopy(anotherCopy), is(true));
+    assertThat(BOOK.isSameCopy(anotherCopy)).isTrue();
   }
 
   @Test
   void shouldBeBorrowable() {
     BOOK.borrowNowByBorrower("a@bc.de");
-    assertThat(BOOK.getBorrowing().getBorrowerEmailAddress(), is("a@bc.de"));
+    assertThat(BOOK.getBorrowing().getBorrowerEmailAddress()).isEqualTo("a@bc.de");
   }
 
   @Test
   void shouldIgnoreNewBorrowWhenBorrowed() {
     BOOK.borrowNowByBorrower("a@bc.de");
     BOOK.borrowNowByBorrower("a@bc.ru");
-    assertThat(BOOK.getBorrowing().getBorrowerEmailAddress(), is("a@bc.de"));
+    assertThat(BOOK.getBorrowing().getBorrowerEmailAddress()).isEqualTo("a@bc.de");
   }
 
   @Test
   void shouldReturnRelevatInfoInToString() {
     String borrowingAsString = BOOK.toString();
-    assertThat(borrowingAsString, containsString("title"));
-    assertThat(borrowingAsString, containsString("author"));
-    assertThat(borrowingAsString, containsString("edition"));
-    assertThat(borrowingAsString, containsString("isbn"));
-    assertThat(borrowingAsString, containsString("yearOfPublication"));
+    assertThat(borrowingAsString)
+        .contains("title")
+        .contains("author")
+        .contains("edition")
+        .contains("isbn")
+        .contains("yearOfPublication");
   }
 }

--- a/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/BorrowingTest.java
+++ b/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/BorrowingTest.java
@@ -1,9 +1,6 @@
 package de.codecentric.psd.worblehat.domain;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.LocalDate;
@@ -24,24 +21,25 @@ class BorrowingTest {
 
   @Test
   void shouldCreateNewBorrowingForToday() {
-    assertThat(borrowing.getBorrowDate(), is(LocalDate.now()));
+    assertThat(borrowing.getBorrowDate()).isEqualTo(LocalDate.now());
   }
 
   @Test
   void shouldReturnBook() {
-    assertThat(borrowing.getBorrowedBook(), is(aBook));
+    assertThat(borrowing.getBorrowedBook()).isEqualTo(aBook);
   }
 
   @Test
   void shouldReturnBorrower() {
-    assertThat(borrowing.getBorrowerEmailAddress(), is("user@domain.com"));
+    assertThat(borrowing.getBorrowerEmailAddress()).isEqualTo("user@domain.com");
   }
 
   @Test
   void shouldReturnRelevatInfoInToString() {
     String borrowingAsString = borrowing.toString();
-    assertThat(borrowingAsString, containsString("borrowerEmailAddress"));
-    assertThat(borrowingAsString, containsString("borrowDate"));
-    assertThat(borrowingAsString, containsString("user@domain.com"));
+    assertThat(borrowingAsString)
+        .contains("borrowerEmailAddress")
+        .contains("borrowDate")
+        .contains("user@domain.com");
   }
 }

--- a/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/StandardBookServiceTest.java
+++ b/worblehat-domain/src/test/java/de/codecentric/psd/worblehat/domain/StandardBookServiceTest.java
@@ -1,10 +1,6 @@
 package de.codecentric.psd.worblehat.domain;
 
-import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -91,15 +87,15 @@ class StandardBookServiceTest {
     ArgumentCaptor<Borrowing> borrowingArgumentCaptor = ArgumentCaptor.forClass(Borrowing.class);
     bookService.borrowBook(aBook.getIsbn(), BORROWER_EMAIL);
     verify(borrowingRepository).save(borrowingArgumentCaptor.capture());
-    assertThat(
-        borrowingArgumentCaptor.getValue().getBorrowerEmailAddress(), equalTo(BORROWER_EMAIL));
+    assertThat(borrowingArgumentCaptor.getValue().getBorrowerEmailAddress())
+        .isEqualTo(BORROWER_EMAIL);
   }
 
-  @Test()
+  @Test
   void shouldNotBorrowWhenBookAlreadyBorrowed() {
     givenALibraryWith(aBorrowedBook);
     Optional<Borrowing> borrowing = bookService.borrowBook(aBorrowedBook.getIsbn(), BORROWER_EMAIL);
-    assertTrue(!borrowing.isPresent());
+    assertThat(borrowing).isNotPresent();
   }
 
   @Test
@@ -108,10 +104,9 @@ class StandardBookServiceTest {
     ArgumentCaptor<Borrowing> borrowingArgumentCaptor = ArgumentCaptor.forClass(Borrowing.class);
     bookService.borrowBook(aBook.getIsbn(), BORROWER_EMAIL);
     verify(borrowingRepository).save(borrowingArgumentCaptor.capture());
-    assertThat(borrowingArgumentCaptor.getValue().getBorrowerEmailAddress(), is(BORROWER_EMAIL));
-    assertThat(
-        borrowingArgumentCaptor.getValue().getBorrowedBook(),
-        either(is(aBook)).or(is(aCopyofBook)));
+    assertThat(borrowingArgumentCaptor.getValue().getBorrowerEmailAddress())
+        .isEqualTo(BORROWER_EMAIL);
+    assertThat(borrowingArgumentCaptor.getValue().getBorrowedBook()).isIn(aBook, aCopyofBook);
   }
 
   @Test
@@ -120,8 +115,9 @@ class StandardBookServiceTest {
     ArgumentCaptor<Borrowing> borrowingArgumentCaptor = ArgumentCaptor.forClass(Borrowing.class);
     bookService.borrowBook(aBook.getIsbn(), BORROWER_EMAIL);
     verify(borrowingRepository).save(borrowingArgumentCaptor.capture());
-    assertThat(borrowingArgumentCaptor.getValue().getBorrowerEmailAddress(), is(BORROWER_EMAIL));
-    assertThat(borrowingArgumentCaptor.getValue().getBorrowedBook(), is(aBook));
+    assertThat(borrowingArgumentCaptor.getValue().getBorrowerEmailAddress())
+        .isEqualTo(BORROWER_EMAIL);
+    assertThat(borrowingArgumentCaptor.getValue().getBorrowedBook()).isEqualTo(aBook);
   }
 
   @Test
@@ -129,56 +125,58 @@ class StandardBookServiceTest {
     givenALibraryWith(aBorrowedBook, aCopyofBorrowedBook);
     ArgumentCaptor<Borrowing> borrowingArgumentCaptor = ArgumentCaptor.forClass(Borrowing.class);
     Optional<Borrowing> borrowing = bookService.borrowBook(aBorrowedBook.getIsbn(), BORROWER_EMAIL);
-    assertThat(borrowing, isEmpty());
+    assertThat(borrowing).isEmpty();
     verify(borrowingRepository, never()).save(any(Borrowing.class));
   }
 
   @Test
   void shouldCreateBook() {
     when(bookRepository.save(any(Book.class))).thenReturn(aBook);
-    Optional<Book> createdBook = bookService.createBook(
-        aBook.getTitle(),
-        aBook.getAuthor(),
-        aBook.getEdition(),
-        aBook.getIsbn(),
-        aBook.getYearOfPublication());
+    Optional<Book> createdBook =
+        bookService.createBook(
+            aBook.getTitle(),
+            aBook.getAuthor(),
+            aBook.getEdition(),
+            aBook.getIsbn(),
+            aBook.getYearOfPublication());
 
     // assert that book was saved to repository
     ArgumentCaptor<Book> bookArgumentCaptor = ArgumentCaptor.forClass(Book.class);
     verify(bookRepository).save(bookArgumentCaptor.capture());
 
     // assert that the information was passed correctly to create the book
-    assertThat(bookArgumentCaptor.getValue().getTitle(), is(aBook.getTitle()));
-    assertThat(bookArgumentCaptor.getValue().getAuthor(), is(aBook.getAuthor()));
-    assertThat(bookArgumentCaptor.getValue().getEdition(), is(aBook.getEdition()));
-    assertThat(bookArgumentCaptor.getValue().getIsbn(), is(aBook.getIsbn()));
-    assertThat(
-        bookArgumentCaptor.getValue().getYearOfPublication(), is(aBook.getYearOfPublication()));
-    assertThat(createdBook.isPresent(), is(true));
-    assertThat(createdBook.get().getTitle(), is(aBook.getTitle()));
-    assertThat(createdBook.get().getAuthor(), is(aBook.getAuthor()));
-    assertThat(createdBook.get().getEdition(), is(aBook.getEdition()));
-    assertThat(createdBook.get().getIsbn(), is(aBook.getIsbn()));
-    assertThat(createdBook.get().getYearOfPublication(), is(aBook.getYearOfPublication()));
+    assertThat(bookArgumentCaptor.getValue().getTitle()).isEqualTo(aBook.getTitle());
+    assertThat(bookArgumentCaptor.getValue().getAuthor()).isEqualTo(aBook.getAuthor());
+    assertThat(bookArgumentCaptor.getValue().getEdition()).isEqualTo(aBook.getEdition());
+    assertThat(bookArgumentCaptor.getValue().getIsbn()).isEqualTo(aBook.getIsbn());
+    assertThat(bookArgumentCaptor.getValue().getYearOfPublication())
+        .isEqualTo(aBook.getYearOfPublication());
+    assertThat(createdBook).isPresent();
+    assertThat(createdBook.get().getTitle()).isEqualTo(aBook.getTitle());
+    assertThat(createdBook.get().getAuthor()).isEqualTo(aBook.getAuthor());
+    assertThat(createdBook.get().getEdition()).isEqualTo(aBook.getEdition());
+    assertThat(createdBook.get().getIsbn()).isEqualTo(aBook.getIsbn());
+    assertThat(createdBook.get().getYearOfPublication()).isEqualTo(aBook.getYearOfPublication());
   }
 
   @Test
   void shouldCreateAnotherCopyOfExistingBook() {
     givenALibraryWith(aBook);
     when(bookRepository.save(any(Book.class))).thenReturn(aBook);
-    Optional<Book> createdBook = bookService.createBook(
-        aBook.getTitle(),
-        aBook.getAuthor(),
-        aBook.getEdition(),
-        aBook.getIsbn(),
-        aBook.getYearOfPublication());
+    Optional<Book> createdBook =
+        bookService.createBook(
+            aBook.getTitle(),
+            aBook.getAuthor(),
+            aBook.getEdition(),
+            aBook.getIsbn(),
+            aBook.getYearOfPublication());
     verify(bookRepository, times(1)).save(any(Book.class));
-    assertThat(createdBook.isPresent(), is(true));
-    assertThat(createdBook.get().getTitle(), is(aBook.getTitle()));
-    assertThat(createdBook.get().getAuthor(), is(aBook.getAuthor()));
-    assertThat(createdBook.get().getEdition(), is(aBook.getEdition()));
-    assertThat(createdBook.get().getIsbn(), is(aBook.getIsbn()));
-    assertThat(createdBook.get().getYearOfPublication(), is(aBook.getYearOfPublication()));
+    assertThat(createdBook).isPresent();
+    assertThat(createdBook.get().getTitle()).isEqualTo(aBook.getTitle());
+    assertThat(createdBook.get().getAuthor()).isEqualTo(aBook.getAuthor());
+    assertThat(createdBook.get().getEdition()).isEqualTo(aBook.getEdition());
+    assertThat(createdBook.get().getIsbn()).isEqualTo(aBook.getIsbn());
+    assertThat(createdBook.get().getYearOfPublication()).isEqualTo(aBook.getYearOfPublication());
   }
 
   @Test
@@ -187,45 +185,49 @@ class StandardBookServiceTest {
     int yearOfPublication = aBook.getYearOfPublication() + 1;
     aCopyofBook.setYearOfPublication(yearOfPublication);
     when(bookRepository.save(any(Book.class))).thenReturn(aCopyofBook);
-    Optional<Book> createdBook = bookService.createBook(
-      aCopyofBook.getTitle(),
-      aCopyofBook.getAuthor(),
-      aCopyofBook.getEdition(),
-      aCopyofBook.getIsbn(),
-      yearOfPublication);
+    Optional<Book> createdBook =
+        bookService.createBook(
+            aCopyofBook.getTitle(),
+            aCopyofBook.getAuthor(),
+            aCopyofBook.getEdition(),
+            aCopyofBook.getIsbn(),
+            yearOfPublication);
     verify(bookRepository, times(1)).save(any(Book.class));
-    assertThat(createdBook.isPresent(), is(true));
-    assertThat(createdBook.get().getTitle(), is(aCopyofBook.getTitle()));
-    assertThat(createdBook.get().getAuthor(), is(aCopyofBook.getAuthor()));
-    assertThat(createdBook.get().getEdition(), is(aCopyofBook.getEdition()));
-    assertThat(createdBook.get().getIsbn(), is(aCopyofBook.getIsbn()));
-    assertThat(createdBook.get().getYearOfPublication(), is(aCopyofBook.getYearOfPublication()));
+    assertThat(createdBook).isPresent();
+    assertThat(createdBook.get().getTitle()).isEqualTo(aCopyofBook.getTitle());
+    assertThat(createdBook.get().getAuthor()).isEqualTo(aCopyofBook.getAuthor());
+    assertThat(createdBook.get().getEdition()).isEqualTo(aCopyofBook.getEdition());
+    assertThat(createdBook.get().getIsbn()).isEqualTo(aCopyofBook.getIsbn());
+    assertThat(createdBook.get().getYearOfPublication())
+        .isEqualTo(aCopyofBook.getYearOfPublication());
   }
 
   @Test
   void shouldNotCreateAnotherCopyOfExistingBookWithDifferentTitle() {
     givenALibraryWith(aBook);
-    Optional<Book> createdBook = bookService.createBook(
-        aBook.getTitle() + "X",
-        aBook.getAuthor(),
-        aBook.getEdition(),
-        aBook.getIsbn(),
-        aBook.getYearOfPublication());
+    Optional<Book> createdBook =
+        bookService.createBook(
+            aBook.getTitle() + "X",
+            aBook.getAuthor(),
+            aBook.getEdition(),
+            aBook.getIsbn(),
+            aBook.getYearOfPublication());
     verify(bookRepository, times(0)).save(any(Book.class));
-    assertThat(createdBook.isPresent(), is(false));
+    assertThat(createdBook).isNotPresent();
   }
 
   @Test
   void shouldNotCreateAnotherCopyOfExistingBookWithDifferentAuthor() {
     givenALibraryWith(aBook);
-    Optional<Book> createdBook = bookService.createBook(
-        aBook.getTitle(),
-        aBook.getAuthor() + "X",
-        aBook.getEdition(),
-        aBook.getIsbn(),
-        aBook.getYearOfPublication());
+    Optional<Book> createdBook =
+        bookService.createBook(
+            aBook.getTitle(),
+            aBook.getAuthor() + "X",
+            aBook.getEdition(),
+            aBook.getIsbn(),
+            aBook.getYearOfPublication());
     verify(bookRepository, times(0)).save(any(Book.class));
-    assertThat(createdBook.isPresent(), is(false));
+    assertThat(createdBook).isNotPresent();
   }
 
   @Test
@@ -234,28 +236,28 @@ class StandardBookServiceTest {
     expectedBooks.add(aBook);
     when(bookRepository.findAllByOrderByTitle()).thenReturn(expectedBooks);
     List<Book> actualBooks = bookService.findAllBooks();
-    assertThat(actualBooks, is(expectedBooks));
+    assertThat(actualBooks).isEqualTo(expectedBooks);
   }
 
   @Test
   void shouldVerifyExistingBooks() {
     when(bookRepository.findByIsbn(aBook.getIsbn())).thenReturn(Collections.singleton(aBook));
-    Boolean bookExists = bookService.bookExists(aBook.getIsbn());
-    assertTrue(bookExists);
+    boolean bookExists = bookService.bookExists(aBook.getIsbn());
+    assertThat(bookExists).isTrue();
   }
 
   @Test
   void shouldVerifyNonexistingBooks() {
     when(bookRepository.findByIsbn(aBook.getIsbn())).thenReturn(Collections.emptySet());
     Boolean bookExists = bookService.bookExists(aBook.getIsbn());
-    assertThat(bookExists, is(false));
+    assertThat(bookExists).isFalse();
   }
 
   @Test
   void shouldFindAllCopiesOfABook() {
     when(bookRepository.findByIsbn("isbn")).thenReturn(Set.of(aBook, aCopyofBook));
     Set<Book> booksByIsbn = bookService.findBooksByIsbn("isbn");
-    assertThat(booksByIsbn, everyItem(hasProperty("isbn", is("isbn"))));
+    assertThat(booksByIsbn).containsExactlyInAnyOrder(aBook, aCopyofBook);
   }
 
   @Test

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BookListControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BookListControllerTest.java
@@ -1,7 +1,6 @@
 package de.codecentric.psd.worblehat.web.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,7 +32,7 @@ class BookListControllerTest {
   @Test
   void shouldNavigateToBookList() throws Exception {
     String url = bookListController.setupForm(modelMap);
-    assertThat(url, is("bookList"));
+    assertThat(url).isEqualTo("bookList");
   }
 
   @Test
@@ -43,6 +42,6 @@ class BookListControllerTest {
     when(bookService.findAllBooks()).thenReturn(bookList);
     bookListController.setupForm(modelMap);
     List<Book> actualBooks = (List<Book>) modelMap.get("books");
-    assertThat(actualBooks, is(bookList));
+    assertThat(actualBooks).isEqualTo(bookList);
   }
 }

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BorrowBookControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/BorrowBookControllerTest.java
@@ -1,9 +1,6 @@
 package de.codecentric.psd.worblehat.web.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -50,7 +47,7 @@ class BorrowBookControllerTest {
 
     borrowBookController.setupForm(modelMap);
 
-    assertThat(modelMap.get("borrowFormData"), is(not(nullValue())));
+    assertThat(modelMap.get("borrowFormData")).isNotNull();
   }
 
   @Test
@@ -59,7 +56,7 @@ class BorrowBookControllerTest {
 
     String navigateTo = borrowBookController.processSubmit(bookBorrowFormData, bindingResult);
 
-    assertThat(navigateTo, is("borrow"));
+    assertThat(navigateTo).isEqualTo("borrow");
   }
 
   @Test
@@ -68,8 +65,8 @@ class BorrowBookControllerTest {
 
     String navigateTo = borrowBookController.processSubmit(bookBorrowFormData, bindingResult);
 
-    assertThat(bindingResult.hasFieldErrors("isbn"), is(true));
-    assertThat(navigateTo, is("borrow"));
+    assertThat(bindingResult.hasFieldErrors("isbn")).isEqualTo(true);
+    assertThat(navigateTo).isEqualTo("borrow");
   }
 
   @Test
@@ -80,9 +77,9 @@ class BorrowBookControllerTest {
         .thenReturn(Collections.singleton(TEST_BOOK));
     String navigateTo = borrowBookController.processSubmit(bookBorrowFormData, bindingResult);
 
-    assertThat(bindingResult.hasFieldErrors("isbn"), is(true));
-    assertThat(bindingResult.getFieldError("isbn").getCode(), is("noBorrowableBooks"));
-    assertThat(navigateTo, is("borrow"));
+    assertThat(bindingResult.hasFieldErrors("isbn")).isEqualTo(true);
+    assertThat(bindingResult.getFieldError("isbn").getCode()).isEqualTo("noBorrowableBooks");
+    assertThat(navigateTo).isEqualTo("borrow");
   }
 
   @Test
@@ -96,7 +93,7 @@ class BorrowBookControllerTest {
 
     String navigateTo = borrowBookController.processSubmit(bookBorrowFormData, bindingResult);
     verify(bookService).borrowBook(TEST_BOOK.getIsbn(), BORROWER_EMAIL);
-    assertThat(navigateTo, is("home"));
+    assertThat(navigateTo).isEqualTo("home");
   }
 
   @Test
@@ -104,6 +101,6 @@ class BorrowBookControllerTest {
     String navigateTo =
         borrowBookController.handleErrors(new Exception(), new MockHttpServletRequest());
 
-    assertThat(navigateTo, is("home"));
+    assertThat(navigateTo).isEqualTo("home");
   }
 }

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/InsertBookControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/InsertBookControllerTest.java
@@ -1,8 +1,6 @@
 package de.codecentric.psd.worblehat.web.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import de.codecentric.psd.worblehat.domain.Book;
@@ -30,7 +28,7 @@ class InsertBookControllerTest {
   private static final Book TEST_BOOK = new Book("title", "author", "edition", "isbn", 2016);
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     bookService = mock(BookService.class);
     insertBookController = new InsertBookController(bookService);
     bookDataFormData = new BookDataFormData();
@@ -43,7 +41,7 @@ class InsertBookControllerTest {
 
     insertBookController.setupForm(modelMap);
 
-    assertThat(modelMap.get("bookDataFormData"), is(not(nullValue())));
+    assertThat(modelMap.get("bookDataFormData")).isNotNull();
   }
 
   @Test
@@ -52,7 +50,7 @@ class InsertBookControllerTest {
 
     String navigateTo = insertBookController.processSubmit(bookDataFormData, bindingResult);
 
-    assertThat(navigateTo, is("insertBooks"));
+    assertThat(navigateTo).isEqualTo("insertBooks");
   }
 
   @Test
@@ -64,7 +62,7 @@ class InsertBookControllerTest {
     String navigateTo = insertBookController.processSubmit(bookDataFormData, bindingResult);
 
     verifyBookIsCreated();
-    assertThat(navigateTo, is("redirect:bookList"));
+    assertThat(navigateTo).isEqualTo("redirect:bookList");
   }
 
   @Test
@@ -75,10 +73,9 @@ class InsertBookControllerTest {
     String navigateTo = insertBookController.processSubmit(bookDataFormData, bindingResult);
 
     verifyBookIsCreated();
-    assertThat(
-        bindingResult.getGlobalErrors(),
-        hasItem(hasProperty("codes", hasItemInArray("duplicateIsbn"))));
-    assertThat(navigateTo, is("insertBooks"));
+    assertThat(bindingResult.getGlobalErrors())
+        .anySatisfy(error -> assertThat(error.getCodes()).contains("duplicateIsbn"));
+    assertThat(navigateTo).isEqualTo("insertBooks");
   }
 
   private void verifyBookIsCreated() {

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/NavigationControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/NavigationControllerTest.java
@@ -1,7 +1,6 @@
 package de.codecentric.psd.worblehat.web.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +10,6 @@ class NavigationControllerTest {
   void shouldNavigateToHome() throws Exception {
     String navigateTo = new NavigationController().home();
 
-    assertThat(navigateTo, is("home"));
+    assertThat(navigateTo).isEqualTo("home");
   }
 }

--- a/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/ReturnAllBooksControllerTest.java
+++ b/worblehat-web/src/test/java/de/codecentric/psd/worblehat/web/controller/ReturnAllBooksControllerTest.java
@@ -1,9 +1,6 @@
 package de.codecentric.psd.worblehat.web.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -41,7 +38,7 @@ class ReturnAllBooksControllerTest {
 
     returnAllBooksController.prepareView(modelMap);
 
-    assertThat(modelMap.get("returnAllBookFormData"), is(not(nullValue())));
+    assertThat(modelMap.get("returnAllBookFormData")).isNotNull();
   }
 
   @Test
@@ -51,7 +48,7 @@ class ReturnAllBooksControllerTest {
     String navigateTo =
         returnAllBooksController.returnAllBooks(returnAllBooksFormData, bindingResult);
 
-    assertThat(navigateTo, is("returnAllBooks"));
+    assertThat(navigateTo).isEqualTo("returnAllBooks");
   }
 
   @Test
@@ -63,6 +60,6 @@ class ReturnAllBooksControllerTest {
         returnAllBooksController.returnAllBooks(returnAllBooksFormData, bindingResult);
 
     verify(bookService).returnAllBooksByBorrower(borrower);
-    assertThat(navigateTo, is("home"));
+    assertThat(navigateTo).isEqualTo("home");
   }
 }


### PR DESCRIPTION
Using this OpenRewrite recipe as a starting point: https://docs.openrewrite.org/recipes/java/testing/hamcrest/migratehamcresttoassertj

But needed to tweak a bit afterwards manually.

Replaced hamcrest dependency with spring-boot-starter-test since spring boot parent is used already. The starter-test includes AssertJ.

Closes #34. 